### PR TITLE
feat: Add Spring Security with JWT authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!--Javassist (Java Programming Assistant) -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.28.0-GA</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,30 @@
             <version>1.2.23</version>
         </dependency>
 
+        <!--        Add spring Security-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!--        Add JWT-->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/ftp/api/config/ApplicationSettings.java
+++ b/src/main/java/com/ftp/api/config/ApplicationSettings.java
@@ -1,11 +1,23 @@
 package com.ftp.api.config;
 
+import com.ftp.api.repositori.JwtAuthRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class ApplicationSettings implements WebMvcConfigurer {
+    private final JwtAuthRepository jwtAuthRepository;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -13,5 +25,28 @@ public class ApplicationSettings implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 .allowedHeaders("*")
                 .allowedMethods("*");
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailService());
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+        return authenticationProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailService() {
+        return jwtAuthRepository::findByNumControl;
     }
 }

--- a/src/main/java/com/ftp/api/config/ApplicationSettings.java
+++ b/src/main/java/com/ftp/api/config/ApplicationSettings.java
@@ -11,20 +11,27 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class ApplicationSettings implements WebMvcConfigurer {
     private final JwtAuthRepository jwtAuthRepository;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("*")
-                .allowedHeaders("*")
-                .allowedMethods("*");
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/src/main/java/com/ftp/api/config/FtpConfig.java
+++ b/src/main/java/com/ftp/api/config/FtpConfig.java
@@ -1,0 +1,15 @@
+package com.ftp.api.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "ftp")
+public class FtpConfig {
+    private String host;
+    private int port;
+    private String user;
+    private String password;
+}

--- a/src/main/java/com/ftp/api/config/SecurityConfig.java
+++ b/src/main/java/com/ftp/api/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.ftp.api.config;
+
+import com.ftp.api.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AuthenticationProvider authenticationProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authRequest ->
+                        authRequest
+                                .requestMatchers("/ftp/auth/login").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .sessionManagement(sessionManager ->
+                        sessionManager
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/ftp/api/controller/AuthController.java
+++ b/src/main/java/com/ftp/api/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.ftp.api.controller;
+
+import com.ftp.api.dto.AuthResponse;
+import com.ftp.api.form.LoginRequest;
+import com.ftp.api.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ftp/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping(path = "/login")
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) throws Exception {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/src/main/java/com/ftp/api/dto/AuthResponse.java
+++ b/src/main/java/com/ftp/api/dto/AuthResponse.java
@@ -1,0 +1,14 @@
+package com.ftp.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthResponse {
+    String token;
+}

--- a/src/main/java/com/ftp/api/entity/User.java
+++ b/src/main/java/com/ftp/api/entity/User.java
@@ -6,7 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Entity
@@ -15,7 +20,7 @@ import java.util.Optional;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "user")
-public class User {
+public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_user")
@@ -39,5 +44,40 @@ public class User {
         this.userPassword = Optional.ofNullable(user.getUserPassword()).orElse(this.userPassword);
         this.userRole = Optional.ofNullable(user.getUserRole()).orElse(this.userRole);
         this.idPersonalInfo = Optional.ofNullable(user.getIdPersonalInfo()).orElse(this.idPersonalInfo);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(userRole.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return this.userPassword;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.numControl;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/src/main/java/com/ftp/api/form/LoginRequest.java
+++ b/src/main/java/com/ftp/api/form/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.ftp.api.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+    String numControl;
+    String password;
+}

--- a/src/main/java/com/ftp/api/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ftp/api/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.ftp.api.jwt;
+
+import com.ftp.api.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String token = getTokenFromRequest(request);
+        final String name;
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        name = jwtService.getNameFromToken(token);
+        if (name != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(name);
+            if (jwtService.isTokenValid(token, userDetails)) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ftp/api/repositori/JwtAuthRepository.java
+++ b/src/main/java/com/ftp/api/repositori/JwtAuthRepository.java
@@ -1,0 +1,10 @@
+package com.ftp.api.repositori;
+
+import com.ftp.api.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JwtAuthRepository extends JpaRepository<User, Integer> {
+    User findByNumControl(String numControl);
+}

--- a/src/main/java/com/ftp/api/repositori/UserRepository.java
+++ b/src/main/java/com/ftp/api/repositori/UserRepository.java
@@ -1,9 +1,11 @@
 package com.ftp.api.repositori;
 
 import com.ftp.api.entity.User;
+import jdk.jfr.Registered;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
+@Registered
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByIdPersonalInfo(Integer idPersonalInfo);
     Optional<User> findByNumControl(String numControl);

--- a/src/main/java/com/ftp/api/service/AuthService.java
+++ b/src/main/java/com/ftp/api/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.ftp.api.service;
+
+import com.ftp.api.dto.AuthResponse;
+import com.ftp.api.form.LoginRequest;
+import com.ftp.api.repositori.JwtAuthRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@PropertySource("classpath:ValidationsMessages.properties")
+public class AuthService {
+    private final AuthenticationManager authenticationManager;
+    private final JwtAuthRepository userRepository;
+    private final JwtService jwtService;
+
+    @Value("${not.found}")
+    private String notFound;
+
+    public AuthResponse login(LoginRequest request) throws Exception {
+        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.getNumControl(), request.getPassword()));
+        validateUserIfExists(request.getNumControl());
+        UserDetails user = userRepository.findByNumControl(request.getNumControl());
+        String token = jwtService.getToken(user);
+        return AuthResponse.builder()
+                .token(token)
+                .build();
+    }
+
+    private void validateUserIfExists(final String controlNumber) throws Exception {
+        if (userRepository.findByNumControl(controlNumber) == null) {
+            throw new Exception(notFound);
+        }
+    }
+}

--- a/src/main/java/com/ftp/api/service/FtpService.java
+++ b/src/main/java/com/ftp/api/service/FtpService.java
@@ -1,6 +1,8 @@
 package com.ftp.api.service;
 
+import com.ftp.api.config.FtpConfig;
 import com.ftp.api.dto.FileInfoDto;
+import lombok.AllArgsConstructor;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.springframework.stereotype.Service;
@@ -15,18 +17,15 @@ import java.util.List;
 import static com.ftp.api.assets.Time.getDateAndTime;
 
 @Service
+@AllArgsConstructor
 public class FtpService {
-
-    private String host = "localhost";
-    private int port = 21;
-    private String user = "usuario1";
-    private String pass = "1234";
+    private final FtpConfig ftpConfig;
 
     // Función para conectar y autenticar al servidor FTP
     private FTPClient loginFtp() throws IOException {
         FTPClient ftpClient = new FTPClient();
-        ftpClient.connect(host, port);
-        boolean loginSuccess = ftpClient.login(user, pass);
+        ftpClient.connect(ftpConfig.getHost(), ftpConfig.getPort());
+        boolean loginSuccess = ftpClient.login(ftpConfig.getUser(), ftpConfig.getPassword());
 
         if (!loginSuccess) {
             ftpClient.disconnect();
@@ -46,7 +45,7 @@ public class FtpService {
             FTPFile[] ftpFiles = ftpClient.listFiles(path);
             for (FTPFile ftpFile : ftpFiles) {
                 FileInfoDto fileInfo = new FileInfoDto();
-                String fullPath = "/" + Paths.get(path, ftpFile.getName()).toString().replace("\\", "/");
+                String fullPath = Paths.get(path, ftpFile.getName()).toString().replace("\\", "/");
                 fileInfo.setName(ftpFile.getName());
                 fileInfo.setTimestamp(getDateAndTime(ftpFile.getTimestamp().getTimeInMillis()));
                 fileInfo.setFile(ftpFile.isFile());
@@ -166,7 +165,6 @@ public class FtpService {
         // Finalmente eliminar el directorio vacío
         return ftpClient.removeDirectory(path);
     }
-
 
     // Cierra la conexión FTP de forma segura
     private void logoutFtp(FTPClient ftpClient) throws IOException {

--- a/src/main/java/com/ftp/api/service/JwtService.java
+++ b/src/main/java/com/ftp/api/service/JwtService.java
@@ -1,0 +1,78 @@
+package com.ftp.api.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final UserService userService;
+    private static final String SECRET_KEY = "586E3272357538782F413F4428472B4B6250655368566B597033733676397924";
+
+    public String getToken(UserDetails user) {
+        return getToken(new HashMap<>(), user);
+    }
+
+    private String getToken(Map<String, Object> extraClaims, UserDetails user) {
+        String jwts = Jwts
+                .builder()
+                .setClaims(extraClaims)
+                .setSubject(user.getUsername())
+                .claim("idUser", userService.getUserByNumControl(user.getUsername()).getIdUser())
+                .claim("idPersonalInfo", userService.getUserByNumControl(user.getUsername()).getIdPersonalInfo())
+                .claim("role", userService.getUserByNumControl(user.getUsername()).getUserRole())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + (1000 * 60 * 60 * 10)))
+                .signWith(getKey(), SignatureAlgorithm.HS256)
+                .compact();
+        return jwts;
+    }
+
+    private Key getKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String getNameFromToken(String token) {
+        return getClaim(token, Claims::getSubject);
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = getNameFromToken(token);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    private Claims getAllClaims(String token) {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public <T> T getClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Date getExpiration(String token) {
+        return getClaim(token, Claims::getExpiration);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return getExpiration(token).before(new Date());
+    }
+}

--- a/src/main/java/com/ftp/api/service/UserService.java
+++ b/src/main/java/com/ftp/api/service/UserService.java
@@ -14,6 +14,7 @@ import com.ftp.api.repositori.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -25,6 +26,7 @@ import java.util.List;
 public class UserService {
     private final UserRepository userRepository;
     private final PersonalInfoRepository personalInfoRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${not.found}")
     private String notFound;
@@ -39,7 +41,7 @@ public class UserService {
         try {
             User user = User.builder()
                     .numControl(form.getControlNumber())
-                    .userPassword(form.getPassword())
+                    .userPassword(passwordEncoder.encode(form.getPassword()))
                     .userRole(form.getUserRole())
                     .idPersonalInfo(form.getIdPersonalInfo())
                     .build();
@@ -82,7 +84,7 @@ public class UserService {
 
             User userInfo = User.builder()
                     .numControl(form.getControlNumber())
-                    .userPassword(form.getPassword())
+                    .userPassword(passwordEncoder.encode(form.getPassword()))
                     .userRole(form.getUserRole())
                     .build();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,5 +6,12 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
 spring.datasource.password=1234
 spring.jpa.show-sql:true
+
+#Configuracion del servidor FTP
+ftp.host=192.168.0.200
+ftp.port=21
+ftp.user=admin
+ftp.password=Chinito1
+
 #flyway.driver=com.mysql.cj.jdbc.Driver
 #flyway.url=jdbc:mysql://localhost:3366/ftp_project


### PR DESCRIPTION
- Integrated Spring Security into the project.
- Implemented `UserDetails` interface in the `User` entity to support authentication using control number and password.
- Updated `getToken` method to generate JWT tokens using control number instead of username.
- Added dependencies for `jwt` in `pom.xml` to enable JWT functionality.
- Created a new endpoint in `AuthController` to fetch user details by control number (`ftp/auth/login`).
- Refactored `UserService` to include a method for retrieving users by control number.