### PR TITLE
Update FTP credentials and add personalPath claim in JWT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: 1234
 
-      FTP_HOST: 192.168.0.200
+      FTP_HOST: 192.168.1.71
       FTP_PORT: 21
-      FTP_USER: admin
-      FTP_PASSWORD: Chinito1
+      FTP_USER: usuario1
+      FTP_PASSWORD: 1234
 
       SPRING_FLYWAY_URL: jdbc:mysql://db:3306/ftp_project
       SPRING_FLYWAY_USER: root

--- a/src/main/java/com/ftp/api/service/JwtService.java
+++ b/src/main/java/com/ftp/api/service/JwtService.java
@@ -26,6 +26,7 @@ public class JwtService {
     }
 
     private String getToken(Map<String, Object> extraClaims, UserDetails user) {
+
         String jwts = Jwts
                 .builder()
                 .setClaims(extraClaims)
@@ -33,6 +34,7 @@ public class JwtService {
                 .claim("idUser", userService.getUserByNumControl(user.getUsername()).getIdUser())
                 .claim("idPersonalInfo", userService.getUserByNumControl(user.getUsername()).getIdPersonalInfo())
                 .claim("role", userService.getUserByNumControl(user.getUsername()).getUserRole())
+                .claim("personalPath", userService.getUserByNumControl(user.getUsername()).getPersonalInfo().get(0).getPersonalPath())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + (1000 * 60 * 60 * 10)))
                 .signWith(getKey(), SignatureAlgorithm.HS256)


### PR DESCRIPTION
Updated FTP-related environment variables in docker-compose.yml to reflect new credentials and host information. Enhanced the JWT generation logic by including a new claim, `personalPath`, for more detailed user information.